### PR TITLE
Update 1.14.6

### DIFF
--- a/src/Xiletrade.Library/Models/Poe/Domain/Parser/ItemFlag.cs
+++ b/src/Xiletrade.Library/Models/Poe/Domain/Parser/ItemFlag.cs
@@ -65,6 +65,8 @@ public sealed record ItemFlag
     internal bool UncutGem { get; }
     internal bool VaultKeys { get; }
     internal bool Scarab { get; }
+    internal bool Graft { get; }
+    internal bool Wombgift { get; }
 
     //flasks-slots
     internal bool Flask { get; }
@@ -231,6 +233,8 @@ public sealed record ItemFlag
         PinnacleKeys = itemClass.Contain(Resources.Resources.ItemClass_pinnacleKeys);
         VaultKeys = itemClass.Contain(Resources.Resources.ItemClass_vaultKeys);
         MapFragment = itemClass.Contain(Resources.Resources.ItemClass_mapFragments);
+        Graft = itemClass.Contain(Resources.Resources.ItemClass_grafts);
+        Wombgift = itemClass.Contain(Resources.Resources.ItemClass_wombgifts);
 
         AllflameEmber = itemClass.Contain(Resources.Resources.ItemClass_allflame) 
             || MapFragment && itemType.Contains(Resources.Resources.General165_AllflameEmber, StringComparison.OrdinalIgnoreCase);
@@ -331,6 +335,7 @@ public sealed record ItemFlag
             : Divcard ? "card" : MemoryLine ? "memoryline" : CapturedBeast ? "monster.beast"
             : Flask ? "flask" : Gems ? "gem" : Sentinel ? "sentinel" : Tincture ? "tincture"
             : SanctumRelic ? "sanctum.relic" : SanctumResearch ? "sanctum.research" : Corpses ? "corpse"
+            : Wombgift ? "wombgift" : Graft ? "graft"
             : Ultimatum || PinnacleKeys || Charm || Logbook || UncutGem || VaultKeys ? string.Empty
             : Pieces ? "currency.piece" : Currency || StackableCurrency ? "currency"
             : string.Empty; 

--- a/src/Xiletrade.Library/Resources/Resources.Designer.cs
+++ b/src/Xiletrade.Library/Resources/Resources.Designer.cs
@@ -3783,6 +3783,24 @@ namespace Xiletrade.Library.Resources {
             }
         }
 		
+		/// <summary>
+        ///   Recherche une chaîne localisée semblable à Wombgifts.
+        /// </summary>
+        public static string ItemClass_wombgifts {
+            get {
+                return ResourceManager.GetString("ItemClass_wombgifts", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Recherche une chaîne localisée semblable à Grafts.
+        /// </summary>
+        public static string ItemClass_grafts {
+            get {
+                return ResourceManager.GetString("ItemClass_grafts", resourceCulture);
+            }
+        }
+		
         /// <summary>
         ///   Recherche une chaîne localisée semblable à Select currencies :
         ///GET and PAY.

--- a/src/Xiletrade.Library/Resources/Resources.de-DE.resx
+++ b/src/Xiletrade.Library/Resources/Resources.de-DE.resx
@@ -1343,6 +1343,12 @@ Möchten Sie den vorherigen überschreiben?</value>
   <data name="ItemClass_vaultKeys" xml:space="preserve">
     <value>Reliquienkammer-Schlüssel</value>
   </data>
+  <data name="ItemClass_wombgifts" xml:space="preserve">
+    <value>Fruchtkeime</value>
+  </data>
+  <data name="ItemClass_grafts" xml:space="preserve">
+    <value>Transplantate</value>
+  </data>
   <data name="Main001_PriceSelect" xml:space="preserve">
     <value>Währungen auswählen:
 ERHALTEN und ZAHLEN</value>

--- a/src/Xiletrade.Library/Resources/Resources.en-US.resx
+++ b/src/Xiletrade.Library/Resources/Resources.en-US.resx
@@ -1345,6 +1345,12 @@ Do you want to overwrite the previous one ?</value>
   <data name="ItemClass_vaultKeys" xml:space="preserve">
     <value>Vault Keys</value>
   </data>
+  <data name="ItemClass_wombgifts" xml:space="preserve">
+    <value>Wombgifts</value>
+  </data>
+  <data name="ItemClass_grafts" xml:space="preserve">
+    <value>Grafts</value>
+  </data>
   <data name="Main001_PriceSelect" xml:space="preserve">
     <value>Select currencies :
 GET and PAY</value>

--- a/src/Xiletrade.Library/Resources/Resources.es-ES.resx
+++ b/src/Xiletrade.Library/Resources/Resources.es-ES.resx
@@ -1347,6 +1347,12 @@ Solo funciona cuando la ventana del juego POE está activa.</value>
   <data name="ItemClass_vaultKeys" xml:space="preserve">
     <value>Llaves de bóvedas</value>
   </data>
+  <data name="ItemClass_wombgifts" xml:space="preserve">
+    <value>Regalos del vientre</value>
+  </data>
+  <data name="ItemClass_grafts" xml:space="preserve">
+    <value>Injertos</value>
+  </data>
   <data name="Main001_PriceSelect" xml:space="preserve">
     <value>Seleccionar monedas:
 OBTENER Y PAGAR</value>

--- a/src/Xiletrade.Library/Resources/Resources.fr-FR.resx
+++ b/src/Xiletrade.Library/Resources/Resources.fr-FR.resx
@@ -1344,6 +1344,12 @@ Voulez-vous écraser le précédent ?</value>
   <data name="ItemClass_vaultKeys" xml:space="preserve">
     <value>Clés de la Salle des coffres</value>
   </data>
+  <data name="ItemClass_wombgifts" xml:space="preserve">
+    <value>Dons de la matrice</value>
+  </data>
+  <data name="ItemClass_grafts" xml:space="preserve">
+    <value>Greffons</value>
+  </data>
   <data name="Main001_PriceSelect" xml:space="preserve">
     <value>Sélectionnez les monnaies :
 Obtenir et Payer</value>

--- a/src/Xiletrade.Library/Resources/Resources.ja-JP.resx
+++ b/src/Xiletrade.Library/Resources/Resources.ja-JP.resx
@@ -1635,6 +1635,12 @@ POE ゲーム ウィンドウがアクティブな場合にのみ機能します
   <data name="ItemClass_vaultKeys" xml:space="preserve">
     <value>金庫の鍵</value>
   </data>
+  <data name="ItemClass_wombgifts" xml:space="preserve">
+    <value>母胎ギフト</value>
+  </data>
+  <data name="ItemClass_grafts" xml:space="preserve">
+    <value>グラフト</value>
+  </data>
   <data name="Main001_PriceSelect" xml:space="preserve">
     <value>通貨を選択:
 欲しい と持っている</value>

--- a/src/Xiletrade.Library/Resources/Resources.ko-KR.resx
+++ b/src/Xiletrade.Library/Resources/Resources.ko-KR.resx
@@ -1347,6 +1347,12 @@ POE 게임 창이 활성화된 경우에만 작동합니다.</value>
   <data name="ItemClass_vaultKeys" xml:space="preserve">
     <value>금고실 열쇠</value>
   </data>
+  <data name="ItemClass_wombgifts" xml:space="preserve">
+    <value>생명의 결실</value>
+  </data>
+  <data name="ItemClass_grafts" xml:space="preserve">
+    <value>기생체</value>
+  </data>
   <data name="Main001_PriceSelect" xml:space="preserve">
     <value>통화 선택 :
 받기 및 지불</value>

--- a/src/Xiletrade.Library/Resources/Resources.pt-BR.resx
+++ b/src/Xiletrade.Library/Resources/Resources.pt-BR.resx
@@ -1347,6 +1347,12 @@ Deseja substituir a anterior?</value>
   <data name="ItemClass_vaultKeys" xml:space="preserve">
     <value>Chaves do Cofre</value>
   </data>
+  <data name="ItemClass_wombgifts" xml:space="preserve">
+    <value>Dádivas do Ventre</value>
+  </data>
+  <data name="ItemClass_grafts" xml:space="preserve">
+    <value>Enxertos</value>
+  </data>
   <data name="Main001_PriceSelect" xml:space="preserve">
     <value>Selecione as moedas:
 OBTER e PAGAR</value>

--- a/src/Xiletrade.Library/Resources/Resources.resx
+++ b/src/Xiletrade.Library/Resources/Resources.resx
@@ -1763,6 +1763,14 @@ Do you want to overwrite the previous one ?</comment>
     <value>Vault Keys</value>
     <comment>Vault Keys</comment>
   </data>
+  <data name="ItemClass_wombgifts" xml:space="preserve">
+    <value>Wombgifts</value>
+    <comment>Wombgifts</comment>
+  </data>
+  <data name="ItemClass_grafts" xml:space="preserve">
+    <value>Grafts</value>
+    <comment>Grafts</comment>
+  </data>
   <data name="Main001_PriceSelect" xml:space="preserve">
     <value>Select currencies :
 GET and PAY</value>

--- a/src/Xiletrade.Library/Resources/Resources.ru-RU.resx
+++ b/src/Xiletrade.Library/Resources/Resources.ru-RU.resx
@@ -1345,6 +1345,12 @@
   <data name="ItemClass_vaultKeys" xml:space="preserve">
     <value>Ключи от хранилищ</value>
   </data>
+  <data name="ItemClass_wombgifts" xml:space="preserve">
+    <value>Дары утробы</value>
+  </data>
+  <data name="ItemClass_grafts" xml:space="preserve">
+    <value>Наросты</value>
+  </data>
   <data name="Main001_PriceSelect" xml:space="preserve">
     <value>Выберите валюты:
 ПОЛУЧАЙ И ОПЛАТИ</value>

--- a/src/Xiletrade.Library/Resources/Resources.th-TH.resx
+++ b/src/Xiletrade.Library/Resources/Resources.th-TH.resx
@@ -1346,6 +1346,12 @@
   <data name="ItemClass_vaultKeys" xml:space="preserve">
     <value>กุญแจคลังวัตถุโบราณ</value>
   </data>
+  <data name="ItemClass_wombgifts" xml:space="preserve">
+    <value>ผลฝากครรภ์</value>
+  </data>
+  <data name="ItemClass_grafts" xml:space="preserve">
+    <value>หัตถ์</value>
+  </data>
   <data name="Main001_PriceSelect" xml:space="preserve">
     <value>เลือกสกุลเงิน:
 รับและจ่าย</value>

--- a/src/Xiletrade.Library/Resources/Resources.zh-CN.resx
+++ b/src/Xiletrade.Library/Resources/Resources.zh-CN.resx
@@ -1426,6 +1426,12 @@
   <data name="ItemClass_vaultKeys" xml:space="preserve">
     <value>宝库钥匙</value>
   </data>
+  <data name="ItemClass_wombgifts" xml:space="preserve">
+    <value>孕育赠礼</value>
+  </data>
+  <data name="ItemClass_grafts" xml:space="preserve">
+    <value>嫁接物</value>
+  </data>
   <data name="Main001_PriceSelect" xml:space="preserve">
     <value>选择货币：
 取款并付款</value>

--- a/src/Xiletrade.Library/Resources/Resources.zh-TW.resx
+++ b/src/Xiletrade.Library/Resources/Resources.zh-TW.resx
@@ -1388,6 +1388,12 @@
   <data name="ItemClass_vaultKeys" xml:space="preserve">
     <value>遺鑰</value>
   </data>
+  <data name="ItemClass_wombgifts" xml:space="preserve">
+    <value>胎贈</value>
+  </data>
+  <data name="ItemClass_grafts" xml:space="preserve">
+    <value>接肢</value>
+  </data>
   <data name="Main001_PriceSelect" xml:space="preserve">
     <value>選擇貨幣：
 取款並付款</value>

--- a/src/Xiletrade.Library/ViewModels/Main/Form/FormViewModel.cs
+++ b/src/Xiletrade.Library/ViewModels/Main/Form/FormViewModel.cs
@@ -711,7 +711,7 @@ public sealed partial class FormViewModel(bool useBulk) : ViewModelBase
         var item = new ItemData(_dm, infodesc);
 
         if (item.Flag.ShowDetail && !item.Flag.Gems && !item.Flag.SanctumResearch && !item.Flag.TrialCoins
-            && !item.Flag.AllflameEmber && !item.Flag.Corpses && !item.Flag.UncutGem)
+            && !item.Flag.AllflameEmber && !item.Flag.Corpses && !item.Flag.UncutGem && !item.Flag.Wombgift)
         {
             return item;
         }

--- a/src/Xiletrade.Library/ViewModels/Main/MainViewModel.cs
+++ b/src/Xiletrade.Library/ViewModels/Main/MainViewModel.cs
@@ -542,7 +542,7 @@ public sealed partial class MainViewModel : ViewModelBase
         var byBase = !item.Flag.Unique && !item.Flag.Normal && !item.Flag.Currency && !item.Flag.Map && !item.Flag.Divcard
             && !item.Flag.CapturedBeast && !item.Flag.Gems && !item.Flag.Flask && !item.Flag.Tincture && !item.Flag.Unidentified
             && !item.Flag.Watchstone && !item.Flag.Invitation && !item.Flag.Logbook && !item.IsSpecialBase && !item.Flag.Tablet
-            && !item.Flag.Charm;
+            && !item.Flag.Charm && !item.Flag.Graft;
 
         var poe2SkillWeapon = item.IsPoe2 && (item.Flag.Wand || item.Flag.Stave || item.Flag.Sceptre);
         Form.ByBase = !byBase || dm.Config.Options.SearchByType || poe2SkillWeapon;
@@ -597,7 +597,8 @@ public sealed partial class MainViewModel : ViewModelBase
 
         bool hideUserControls = false;
         if (!item.Flag.Invitation && !item.Flag.Map && !item.Flag.AllflameEmber && (item.Flag.Currency
-            && !item.Flag.Chronicle && !item.Flag.Ultimatum && !item.Flag.FilledCoffin || (item.IsExchangeCurrency && !item.Flag.Tablet && !item.Flag.Waystones)
+            && !item.Flag.Chronicle && !item.Flag.Ultimatum && !item.Flag.FilledCoffin
+            || (item.IsExchangeCurrency && !item.Flag.Tablet && !item.Flag.Waystones)
             || item.Flag.CapturedBeast || item.Flag.MemoryLine))
         {
             hideUserControls = true;
@@ -622,7 +623,7 @@ public sealed partial class MainViewModel : ViewModelBase
             Form.Panel.FacetorMin = item.Option[Resources.Resources.Main154_tbFacetor].Replace(" ", string.Empty);
         }
         var level = minMaxList.GetModel(StatPanel.CommonItemLevel);
-        if (hideUserControls && item.Flag.UncutGem)
+        if (hideUserControls && (item.Flag.UncutGem || item.Flag.Wombgift))
         {
             Form.Visible.PanelForm = true;
             Form.Visible.Quality = false;

--- a/src/Xiletrade.UI.WPF/Xiletrade.UI.WPF.csproj
+++ b/src/Xiletrade.UI.WPF/Xiletrade.UI.WPF.csproj
@@ -8,9 +8,9 @@
     <Copyright>Copyright © 2025 maxensas</Copyright>
     <AssemblyTitle>Xiletrade WPF User Interface</AssemblyTitle>
     <AssemblyName>Xiletrade</AssemblyName>
-    <Version>1.14.5</Version>
-    <AssemblyVersion>1.14.5.0</AssemblyVersion>
-    <FileVersion>1.14.5.0</FileVersion>
+    <Version>1.14.6</Version>
+    <AssemblyVersion>1.14.6.0</AssemblyVersion>
+    <FileVersion>1.14.6.0</FileVersion>
     <PackageProjectUrl>https://github.com/maxensas/xiletrade</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/maxensas/xiletrade/releases</PackageReleaseNotes>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>


### PR DESCRIPTION
`Updated`
- Can now price check Grafts and Wombgifts correctly.

**Previsouly in 1.14.5 :**

`Updated`
- Now able to price check Foulborn uniques.
- Display exceptions again on the price bar.

`Fixed`
- Fix JSON exception (unidentified unique map)

`Note`
```
Mutated mods from Foulborn uniques will be displayed in pink color.
```