### PR TITLE
Update 1.15.4 : Fix for PoE2 price check (new response API format)

### DIFF
--- a/src/Xiletrade.Library/Models/Application/Serialization/Converter/ModAffixConverter.cs
+++ b/src/Xiletrade.Library/Models/Application/Serialization/Converter/ModAffixConverter.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xiletrade.Library.Models.Poe.Contract;
+using Xiletrade.Library.Services;
+
+namespace Xiletrade.Library.Models.Application.Serialization.Converter;
+
+public class ModAffixConverter : JsonConverter<List<ModAffix>>
+{
+    private static IServiceProvider _serviceProvider;
+
+    public ModAffixConverter(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public override List<ModAffix> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType is not JsonTokenType.StartArray)
+            throw new JsonException();
+
+        var result = new List<ModAffix>();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType is JsonTokenType.EndArray)
+                return result;
+
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.String:
+                    result.Add(new ModAffix{ Text = reader.GetString()});
+                    break;
+
+                case JsonTokenType.StartObject:
+                    var context = _serviceProvider.GetRequiredService<DataManagerService>().Json.DefaultContext;
+                    var mod = JsonSerializer.Deserialize(ref reader, context.ModAffix);
+                    result.Add(mod);
+                    break;
+
+                default:
+                    throw new JsonException($"Unexpected type : {reader.TokenType}");
+            }
+        }
+
+        throw new JsonException();
+    }
+
+    public override void Write(Utf8JsonWriter writer, List<ModAffix> value, JsonSerializerOptions options)
+    {
+        var context = _serviceProvider.GetRequiredService<DataManagerService>().Json.DefaultContext;
+        JsonSerializer.Serialize(writer, value, context.ModAffix);
+    }
+}

--- a/src/Xiletrade.Library/Models/Application/Serialization/JsonHelper.cs
+++ b/src/Xiletrade.Library/Models/Application/Serialization/JsonHelper.cs
@@ -79,6 +79,7 @@ public sealed class JsonHelper : StringCache
         //options.Converters.Add(new QueryTypeJsonConverter(serviceProvider));
         //options.Converters.Add(new ArrayStringJsonConverter());
         //options.Converters.Add(new FlexibleStringConverter());
+        options.Converters.Add(new ModAffixConverter(serviceProvider));
         options.Converters.Add(new ItemExtendedOrEmptyArrayConverter(serviceProvider));
         options.Converters.Add(new ValueTupleListConverter());
         options.Converters.Add(new HashMapConverter());

--- a/src/Xiletrade.Library/Models/Application/Serialization/SourceGeneration/SourceGenerationContext.cs
+++ b/src/Xiletrade.Library/Models/Application/Serialization/SourceGeneration/SourceGenerationContext.cs
@@ -135,6 +135,7 @@ namespace Xiletrade.Library.Models.Serialization.SourceGeneration;
 [JsonSerializable(typeof(DustLevel))]
 [JsonSerializable(typeof(OAuthToken))]
 [JsonSerializable(typeof(SearchPresetData))]
+[JsonSerializable(typeof(ModAffix))]
 public partial class SourceGenerationContext : JsonSerializerContext
 {
     internal JsonTypeInfo<T> GetTypeGenerated<T>() where T : class

--- a/src/Xiletrade.Library/Models/Poe/Contract/ExtendedAffix.cs
+++ b/src/Xiletrade.Library/Models/Poe/Contract/ExtendedAffix.cs
@@ -6,12 +6,15 @@ namespace Xiletrade.Library.Models.Poe.Contract;
 public sealed class ExtendedAffix
 {
     [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string Name { get; set; }
 
     [JsonPropertyName("tier")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string Tier { get; set; }
 
     [JsonPropertyName("level")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int Level { get; set; }
 
     [JsonPropertyName("magnitudes")]

--- a/src/Xiletrade.Library/Models/Poe/Contract/ExtendedMagnitudes.cs
+++ b/src/Xiletrade.Library/Models/Poe/Contract/ExtendedMagnitudes.cs
@@ -5,6 +5,7 @@ namespace Xiletrade.Library.Models.Poe.Contract;
 public sealed class ExtendedMagnitudes
 {
     [JsonPropertyName("hash")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string Hash { get; set; }
 
     [JsonPropertyName("min")]

--- a/src/Xiletrade.Library/Models/Poe/Contract/ItemDataApi.cs
+++ b/src/Xiletrade.Library/Models/Poe/Contract/ItemDataApi.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Xiletrade.Library.Models.Poe.Contract;
 
@@ -51,10 +52,10 @@ public sealed class ItemDataApi
 
     [JsonPropertyName("runeMods")]
     public string[] RuneMods { get; set; }
-
+  
     [JsonPropertyName("explicitMods")]
-    public string[] ExplicitMods { get; set; }
-
+    public List<ModAffix> ExplicitMods { get; set; }
+    
     [JsonPropertyName("desecratedMods")]
     public string[] DesecratedMods { get; set; }
 

--- a/src/Xiletrade.Library/Models/Poe/Contract/ModAffix.cs
+++ b/src/Xiletrade.Library/Models/Poe/Contract/ModAffix.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Xiletrade.Library.Models.Poe.Contract;
+
+public sealed class ModAffix
+{
+    [JsonPropertyName("description")]
+    public string Description { get; set; }
+
+    [JsonPropertyName("hash")]
+    public string Hash { get; set; }
+
+    [JsonPropertyName("mods")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<ExtendedAffix> Mods { get; set; }
+
+    [JsonIgnore]
+    public string Text { get; set; }
+}

--- a/src/Xiletrade.Library/Models/Poe/Domain/SaleItem.cs
+++ b/src/Xiletrade.Library/Models/Poe/Domain/SaleItem.cs
@@ -112,9 +112,10 @@ public sealed record SaleItem
             && item.Extended?.Hashes?.Fractured?.Count > 0
             && item.Extended?.Mods?.Fractured?.Count > 0;
         var mutated = item.MutatedMods?.Length > 0;
-        IsVisibleExplicit = desecrated || fractured || item.ExplicitMods?.Length > 0
-            && item.Extended?.Hashes?.Explicit?.Count > 0
-            && item.Extended?.Mods?.Explicit?.Count > 0;
+        // temp (handling PoE1 & PoE2 response APIs)
+        IsVisibleExplicit = desecrated || fractured || item.ExplicitMods?.Count > 0
+            && (item.Extended?.Hashes?.Explicit?.Count > 0 || item.ExplicitMods[0]?.Hash?.Length > 0)
+            && (item.Extended?.Mods?.Explicit?.Count > 0 || item.ExplicitMods[0]?.Mods?.Count > 0);
 
         if (item.BaseType?.Length > 0)
         {
@@ -243,19 +244,27 @@ public sealed record SaleItem
                     if (modId >= 0 && modId < item.Extended.Mods.Fractured.Count)
                     {
                         lExplicit.Add(new(item.Extended.Mods.Fractured[modId],
-                        item.FracturedMods[i].ParseBracketMod(), isFractured: true));
+                            item.FracturedMods[i].ParseBracketMod(), isFractured: true));
                     }
                 }
             }
 
-            for (int i = 0; i < item.ExplicitMods?.Length; i++)
+            for (int i = 0; i < item.ExplicitMods?.Count; i++)
             {
-                //var statId = item.Extended.Hashes.Explicit[i].Id;
-                var modId = item.Extended.Hashes.Explicit[i].Values.FirstOrDefault();
-                if (modId >= 0 && modId < item.Extended.Mods.Explicit.Count)
+                if (item.ExplicitMods[i].Text?.Length > 0) // PoE1 API
                 {
-                    lExplicit.Add(new(item.Extended.Mods.Explicit[modId],
-                        item.ExplicitMods[i].ParseBracketMod()));
+                    //var statId = item.Extended.Hashes.Explicit[i].Id;
+                    var modId = item.Extended.Hashes.Explicit[i].Values.FirstOrDefault();
+                    if (modId >= 0 && modId < item.Extended.Mods.Explicit.Count)
+                    {
+                        lExplicit.Add(new(item.Extended.Mods.Explicit[modId],
+                            item.ExplicitMods[i].Text.ParseBracketMod()));
+                    }
+                }
+                if (item.ExplicitMods[i].Description?.Length > 0) // PoE2 API
+                {
+                    var affix = item.ExplicitMods[i].Mods.Count > 0 ? item.ExplicitMods[i].Mods[0] : new();
+                    lExplicit.Add(new(affix, item.ExplicitMods[i].Description.ParseBracketMod()));
                 }
             }
 
@@ -267,7 +276,7 @@ public sealed record SaleItem
                     if (modId >= 0 && modId < item.Extended.Mods.Desecrated.Count)
                     {
                         lExplicit.Add(new(item.Extended.Mods.Desecrated[modId],
-                        item.DesecratedMods[i].ParseBracketMod(), isDesecrated: true));
+                            item.DesecratedMods[i].ParseBracketMod(), isDesecrated: true));
                     }
                 }
             }
@@ -275,7 +284,7 @@ public sealed record SaleItem
             // GGG will probably update this behaviour if mutated mods will remain in POE.
             if (mutated)
             {
-                var nbExplicit = item.ExplicitMods.Length;
+                var nbExplicit = item.ExplicitMods.Count;
                 // mutated are the latests from explicit list
                 var mapMutated = item.Extended.Hashes.Explicit.Skip(nbExplicit).ToList();
                 //var modsMutated = item.Extended.Mods.Explicit.Skip(nbExplicit).ToList();
@@ -292,7 +301,7 @@ public sealed record SaleItem
                     if (modId >= 0 && modId < item.Extended.Mods.Explicit.Count)
                     {
                         lExplicit.Add(new(item.Extended.Mods.Explicit[modId],
-                        item.MutatedMods[i].ParseBracketMod(), isMutated: true));
+                            item.MutatedMods[i].ParseBracketMod(), isMutated: true));
                     }
                 }
             }
@@ -305,7 +314,7 @@ public sealed record SaleItem
                     if (modId >= 0 && modId < item.Extended.Mods.Crafted.Count)
                     {
                         lExplicit.Add(new(item.Extended.Mods.Crafted[modId],
-                        item.CraftedMods[i].ParseBracketMod(), isCrafted: true));
+                            item.CraftedMods[i].ParseBracketMod(), isCrafted: true));
                     }
                 }
             }

--- a/src/Xiletrade.UI.WPF/Xiletrade.UI.WPF.csproj
+++ b/src/Xiletrade.UI.WPF/Xiletrade.UI.WPF.csproj
@@ -8,9 +8,9 @@
     <Copyright>Copyright © 2026 maxensas</Copyright>
     <AssemblyTitle>Xiletrade WPF User Interface</AssemblyTitle>
     <AssemblyName>Xiletrade</AssemblyName>
-    <Version>1.15.3</Version>
-    <AssemblyVersion>1.15.3.0</AssemblyVersion>
-    <FileVersion>1.15.3.0</FileVersion>
+    <Version>1.15.4</Version>
+    <AssemblyVersion>1.15.4.0</AssemblyVersion>
+    <FileVersion>1.15.4.0</FileVersion>
     <PackageProjectUrl>https://github.com/maxensas/xiletrade</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/maxensas/xiletrade/releases</PackageReleaseNotes>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>


### PR DESCRIPTION
_This update allows Xiletrade to work again following changes to the trading site; further fixes will be available soon._

`Fixed`
- Now handle new PoE2 response API format with backward compatibility. #106 